### PR TITLE
Make the components positioned relative to the editor panel

### DIFF
--- a/app/bundles/app/strut.config/config.js
+++ b/app/bundles/app/strut.config/config.js
@@ -1,13 +1,27 @@
-define(function () {
+define(['jquery'],function ($) {
+        var bodyHeight = $("body").height();
+        var bodyWidth = $("body").width();
+        var actualAvailableHeightforSlide = bodyHeight - 120;
+        var actualAvailableWidthforSlide = bodyWidth - 230;
+
+        if (actualAvailableWidthforSlide < (actualAvailableHeightforSlide * (16 / 9))) {
+            actualAvailableHeightforSlide = actualAvailableWidthforSlide * (9 / 16);
+            
+        }
+        
+        else {
+            actualAvailableWidthforSlide = actualAvailableHeightforSlide * (16 / 9);
+        }
+    
 	var config = {
 		slide: {
 			size: {
-				width: 1024,
-				height: 768
+				width: actualAvailableWidthforSlide,
+				height: actualAvailableHeightforSlide
 			},
 			overviewSize: {
-				width: 75,
-				height: 50
+				width: 140,
+				height: 90
 			}
 		}
 	};


### PR DESCRIPTION
1) when the slide size is small, the default text box is coming outside - fixed